### PR TITLE
Fixed [PC-1200] Accumulators Double Counting, reduced dataframe actions - Validator App

### DIFF
--- a/integrations/spark/spark-validate-cleanse/spark-validate-cleanse-app/pom.xml
+++ b/integrations/spark/spark-validate-cleanse/spark-validate-cleanse-app/pom.xml
@@ -129,6 +129,12 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>com.holdenkarau</groupId>
+      <artifactId>spark-testing-base_2.10</artifactId>
+      <version>${spark.version}_0.6.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/integrations/spark/spark-validate-cleanse/spark-validate-cleanse-app/src/main/java/com/thinkbiganalytics/spark/datavalidator/CleansedRowResult.java
+++ b/integrations/spark/spark-validate-cleanse/spark-validate-cleanse-app/src/main/java/com/thinkbiganalytics/spark/datavalidator/CleansedRowResult.java
@@ -1,0 +1,36 @@
+package com.thinkbiganalytics.spark.datavalidator;
+
+/*-
+ * #%L
+ * thinkbig-spark-validate-cleanse-app
+ * %%
+ * Copyright (C) 2017 ThinkBig Analytics
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.apache.spark.sql.Row;
+import java.io.Serializable;
+
+/**
+ * Created by cp186050 on 14/2/17.
+ */
+// Wrapper class to contain our cleansed row and its column validation results
+public class CleansedRowResult implements Serializable {
+
+    public Row row;
+    public boolean[] columnsValid;
+    public boolean rowIsValid;
+
+}

--- a/integrations/spark/spark-validate-cleanse/spark-validate-cleanse-app/src/main/java/com/thinkbiganalytics/spark/datavalidator/CleansedRowResult.java
+++ b/integrations/spark/spark-validate-cleanse/spark-validate-cleanse-app/src/main/java/com/thinkbiganalytics/spark/datavalidator/CleansedRowResult.java
@@ -23,10 +23,9 @@ package com.thinkbiganalytics.spark.datavalidator;
 import org.apache.spark.sql.Row;
 import java.io.Serializable;
 
-/**
- * Created by cp186050 on 14/2/17.
+/*
+ * Wrapper class to contain our cleansed row and its column validation results
  */
-// Wrapper class to contain our cleansed row and its column validation results
 public class CleansedRowResult implements Serializable {
 
     public Row row;

--- a/integrations/spark/spark-validate-cleanse/spark-validate-cleanse-app/src/main/java/com/thinkbiganalytics/spark/datavalidator/Validator.java
+++ b/integrations/spark/spark-validate-cleanse/spark-validate-cleanse-app/src/main/java/com/thinkbiganalytics/spark/datavalidator/Validator.java
@@ -205,7 +205,7 @@ public class Validator implements Serializable {
             });
 
             // Counts of invalid columns, total valid rows and total invalid rows
-            long[] fieldInvalidCounts = CleansedRowResultsValidationCounts(cleansedRowResultRDD, schema.length);
+            long[] fieldInvalidCounts = cleansedRowResultsValidationCounts(cleansedRowResultRDD, schema.length);
 
             final DataSet validatedDF = scs.toDataSet(getHiveContext(), newResults, sourceSchema);
 
@@ -436,7 +436,7 @@ public class Validator implements Serializable {
     /**
      * Performs counts of invalid columns, total valid and total invalid on a JavaRDD<CleansedRowResults>
      */
-    public long[] CleansedRowResultsValidationCounts(JavaRDD<CleansedRowResult> cleansedRowResultJavaRDD, int schemaLength) {
+    public long[] cleansedRowResultsValidationCounts(JavaRDD<CleansedRowResult> cleansedRowResultJavaRDD, int schemaLength) {
 
         final int schemaLen = schemaLength;
 

--- a/integrations/spark/spark-validate-cleanse/spark-validate-cleanse-app/src/main/java/com/thinkbiganalytics/spark/datavalidator/Validator.java
+++ b/integrations/spark/spark-validate-cleanse/spark-validate-cleanse-app/src/main/java/com/thinkbiganalytics/spark/datavalidator/Validator.java
@@ -196,8 +196,8 @@ public class Validator implements Serializable {
                 }
             }).persist(StorageLevel.fromString(params.getStorageLevel()));
 
-            // Return a new dataframe based on whether values are valid or invalid
-            JavaRDD<Row> newResults = cleansedRowResultRDD.map(new Function<CleansedRowResult, Row>() {
+            // Return a new rdd based on whether values are valid or invalid
+            JavaRDD<Row> newResultsRDD = cleansedRowResultRDD.map(new Function<CleansedRowResult, Row>() {
                 @Override
                 public Row call(CleansedRowResult cleansedRowResult) throws Exception {
                     return cleansedRowResult.row;
@@ -207,7 +207,7 @@ public class Validator implements Serializable {
             // Counts of invalid columns, total valid rows and total invalid rows
             long[] fieldInvalidCounts = cleansedRowResultsValidationCounts(cleansedRowResultRDD, schema.length);
 
-            final DataSet validatedDF = scs.toDataSet(getHiveContext(), newResults, sourceSchema);
+            final DataSet validatedDF = scs.toDataSet(getHiveContext(), newResultsRDD, sourceSchema);
 
             // Pull out just the valid or invalid records
             DataSet invalidDF = null;
@@ -230,7 +230,7 @@ public class Validator implements Serializable {
             long validCount = fieldInvalidCounts[schema.length];
             long invalidCount = fieldInvalidCounts[schema.length + 1];
 
-            newResults.unpersist();
+            cleansedRowResultRDD.unpersist();
 
             log.info("Valid count {} invalid count {}", validCount, invalidCount);
 

--- a/integrations/spark/spark-validate-cleanse/spark-validate-cleanse-app/src/main/java/com/thinkbiganalytics/spark/datavalidator/Validator.java
+++ b/integrations/spark/spark-validate-cleanse/spark-validate-cleanse-app/src/main/java/com/thinkbiganalytics/spark/datavalidator/Validator.java
@@ -58,7 +58,14 @@ import org.springframework.stereotype.Component;
 
 import java.io.Serializable;
 import java.lang.reflect.ParameterizedType;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
 
 
 /**

--- a/integrations/spark/spark-validate-cleanse/spark-validate-cleanse-app/src/test/java/com/thinkbiganalytics/spark/datavalidator/ValidatorTest.java
+++ b/integrations/spark/spark-validate-cleanse/spark-validate-cleanse-app/src/test/java/com/thinkbiganalytics/spark/datavalidator/ValidatorTest.java
@@ -171,7 +171,7 @@ public class ValidatorTest extends SharedJavaSparkContext implements Serializabl
                                                                        cleansedRowResult1, cleansedRowResult1, cleansedRowResult1,
                                                                        cleansedRowResult1, cleansedRowResult2, cleansedRowResult3);
         JavaRDD<CleansedRowResult> inputRDD = jsc().parallelize(cleansedRowResultsList, 1);
-        long[] output = validator.CleansedRowResultsValidationCounts(inputRDD, 5);
+        long[] output = validator.cleansedRowResultsValidationCounts(inputRDD, 5);
 
         // Create the expected output
         long[] expectedOutput = {1l, 2l, 0l, 0l, 2l, 7l, 2l};

--- a/integrations/spark/spark-validate-cleanse/spark-validate-cleanse-app/src/test/java/com/thinkbiganalytics/spark/datavalidator/ValidatorTest.java
+++ b/integrations/spark/spark-validate-cleanse/spark-validate-cleanse-app/src/test/java/com/thinkbiganalytics/spark/datavalidator/ValidatorTest.java
@@ -32,8 +32,6 @@ import com.thinkbiganalytics.policy.validation.ValidationResult;
 import com.thinkbiganalytics.spark.validation.HCatDataType;
 
 import org.apache.spark.api.java.JavaRDD;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.RowFactory;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -170,7 +168,7 @@ public class ValidatorTest extends SharedJavaSparkContext implements Serializabl
         List<CleansedRowResult> cleansedRowResultsList = Arrays.asList(cleansedRowResult1, cleansedRowResult1, cleansedRowResult1,
                                                                        cleansedRowResult1, cleansedRowResult1, cleansedRowResult1,
                                                                        cleansedRowResult1, cleansedRowResult2, cleansedRowResult3);
-        JavaRDD<CleansedRowResult> inputRDD = jsc().parallelize(cleansedRowResultsList, 1);
+        JavaRDD<CleansedRowResult> inputRDD = jsc().parallelize(cleansedRowResultsList);
         long[] output = validator.cleansedRowResultsValidationCounts(inputRDD, 5);
 
         // Create the expected output

--- a/integrations/spark/spark-validate-cleanse/spark-validate-cleanse-app/src/test/java/com/thinkbiganalytics/spark/datavalidator/ValidatorTest.java
+++ b/integrations/spark/spark-validate-cleanse/spark-validate-cleanse-app/src/test/java/com/thinkbiganalytics/spark/datavalidator/ValidatorTest.java
@@ -168,7 +168,7 @@ public class ValidatorTest extends SharedJavaSparkContext implements Serializabl
         List<CleansedRowResult> cleansedRowResultsList = Arrays.asList(cleansedRowResult1, cleansedRowResult1, cleansedRowResult1,
                                                                        cleansedRowResult1, cleansedRowResult1, cleansedRowResult1,
                                                                        cleansedRowResult1, cleansedRowResult2, cleansedRowResult3);
-        JavaRDD<CleansedRowResult> inputRDD = jsc().parallelize(cleansedRowResultsList);
+        JavaRDD<CleansedRowResult> inputRDD = jsc().parallelize(cleansedRowResultsList, 4);
         long[] output = validator.cleansedRowResultsValidationCounts(inputRDD, 5);
 
         // Create the expected output

--- a/integrations/spark/spark-validate-cleanse/spark-validate-cleanse-app/src/test/java/com/thinkbiganalytics/spark/datavalidator/ValidatorTest.java
+++ b/integrations/spark/spark-validate-cleanse/spark-validate-cleanse-app/src/test/java/com/thinkbiganalytics/spark/datavalidator/ValidatorTest.java
@@ -20,6 +20,7 @@ package com.thinkbiganalytics.spark.datavalidator;
  * #L%
  */
 
+import com.holdenkarau.spark.testing.SharedJavaSparkContext;
 import com.thinkbiganalytics.policy.FieldPoliciesJsonTransformer;
 import com.thinkbiganalytics.policy.FieldPolicy;
 import com.thinkbiganalytics.policy.standardization.SimpleRegexReplacer;
@@ -30,22 +31,30 @@ import com.thinkbiganalytics.policy.validation.ValidationPolicy;
 import com.thinkbiganalytics.policy.validation.ValidationResult;
 import com.thinkbiganalytics.spark.validation.HCatDataType;
 
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.Serializable;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-public class ValidatorTest {
+public class ValidatorTest extends SharedJavaSparkContext implements Serializable {
+
+    private static final long serialVersionUID = -5681683598336701496L;
 
     private Validator validator;
 
@@ -137,5 +146,37 @@ public class ValidatorTest {
         Map<String, FieldPolicy> policyMap = new FieldPoliciesJsonTransformer(fieldPolicyJson).buildPolicies();
         assertEquals(policyMap.size(), 10);
 
+    }
+
+    @Test
+    public void testCleansedRowResultsValidationCounts() {
+
+        // Create and run the test
+        CleansedRowResult cleansedRowResult1 = new CleansedRowResult();
+        cleansedRowResult1.rowIsValid = true;
+        boolean[] columnsValid1 = {true, true, true, true, true};
+        cleansedRowResult1.columnsValid = columnsValid1;
+
+        CleansedRowResult cleansedRowResult2 = new CleansedRowResult();
+        cleansedRowResult2.rowIsValid = false;
+        boolean[] columnsValid2 = {true, false, true, true, false};
+        cleansedRowResult2.columnsValid = columnsValid2;
+
+        CleansedRowResult cleansedRowResult3 = new CleansedRowResult();
+        cleansedRowResult3.rowIsValid = false;
+        boolean[] columnsValid3 = {false, false, true, true, false};
+        cleansedRowResult3.columnsValid = columnsValid3;
+
+        List<CleansedRowResult> cleansedRowResultsList = Arrays.asList(cleansedRowResult1, cleansedRowResult1, cleansedRowResult1,
+                                                                       cleansedRowResult1, cleansedRowResult1, cleansedRowResult1,
+                                                                       cleansedRowResult1, cleansedRowResult2, cleansedRowResult3);
+        JavaRDD<CleansedRowResult> inputRDD = jsc().parallelize(cleansedRowResultsList, 1);
+        long[] output = validator.CleansedRowResultsValidationCounts(inputRDD, 5);
+
+        // Create the expected output
+        long[] expectedOutput = {1l, 2l, 0l, 0l, 2l, 7l, 2l};
+
+        // Run assertions on output and expected output
+        assertArrayEquals(expectedOutput, output);
     }
 }


### PR DESCRIPTION
Fixed accumulator issue with spark validator app (incrementing accumulators in transformation functions cannot guarantee double counting will occur). Also reduce the number of actions performed on Dataframes to just 2 calls.